### PR TITLE
.NET LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
             ghcr.io/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && matrix.from-version == '22.04' }}
-            type=raw,value=${{ matrix.from-version }}
+            type=raw,value=${{ matrix.from-version }},enable=${{ github.ref == 'refs/heads/main' }}
             type=schedule
             type=ref,event=branch,prefix=${{ matrix.from-version }}-
             type=ref,event=pr
@@ -84,7 +84,6 @@ jobs:
             FROM_IMAGE=catthehacker/${{ matrix.from-distro }}
             FROM_FLAVOR=${{ matrix.from-flavor }}
             FROM_VERSION=${{ matrix.from-version }}
-            TARGETVERSRION=${{ matrix.from-version }}
           cache-from: |
             type=gha,ref=${{ github.ref }}
             type=gha,ref=refs/heads/main

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Docker images for [nektos/act](https://github.com/nektos/act)
+# :whale: Docker images for [nektos/act](https://github.com/nektos/act)
 
 ## What
 
@@ -11,6 +11,16 @@ If you don't know it yet, I highly recommend to check it out :neckbeard:
 
 In the other Images I had problems with executing azure related tools, so I decided to modify a image
 from [catthehacker](https://github.com/catthehacker/docker_images)
+
+## How to use
+
+Add this to your `~/.actrc`:
+
+```shell
+-P ubuntu-latest=mauwii/ubuntu-act:latest
+-P ubuntu-22.04=mauwii/ubuntu-act:22.04
+-P ubuntu-20.04=mauwii/ubuntu-act:20.04
+```
 
 ## :warning: Could change frequently :warning:
 

--- a/linux/ubuntu/Dockerfile
+++ b/linux/ubuntu/Dockerfile
@@ -8,37 +8,66 @@ FROM --platform=$TARGETPLATFORM ${FROM_IMAGE}:${FROM_FLAVOR}-${FROM_VERSION}
 ARG TARGETARCH
 ARG FROM_VERSION
 
-# set default shell
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# SHELL ["/bin/bash", "--no-profile", "-e", "-o", "pipefail", "-c"]
+# set default shell to bash with pipefail and no profile
+SHELL ["/bin/bash", "--noprofile", "-e", "-o", "pipefail", "-c"]
 
-# install dotnet
-ENV DOTNET_ROOT=/opt/hostedtoolcache/dotnet
-ENV DOTNET_TOOLS=${DOTNET_ROOT}/tools
-ENV PATH="$PATH:$DOTNET_ROOT:$DOTNET_TOOLS"
-RUN deps=(libc6 libgcc1 libstdc++6 zlib1g libgssapi-krb5-2 ) \
-    && if [[ $FROM_VERSION == "20.04" ]]; then deps+=(libicu66 libssl1.1); fi \
-    && if [[ $FROM_VERSION == "22.04" ]]; then deps+=(libicu70 libssl3 libunwind8); fi \
-    && apt-get update && apt-get install -y --no-install-recommends "${deps[@]}" \
-    && curl -LO https://dot.net/v1/dotnet-install.sh \
+# create targetproc file for later use
+RUN export targetarch=${TARGETARCH} \
+    && if [ ${targetarch} = "amd64" ]; then export targetarch="x64"; fi \
+    && echo ${targetarch} >/tmp/targetproc
+
+# install .NET SDK LTS
+ENV DOTNET_ROOT=${AGENT_TOOLSDIRECTORY}/dotnet
+ENV PATH=${DOTNET_ROOT}:${PATH}
+ENV DOTNET_GENERATE_ASPNET_CERTIFICATE=false
+ENV DOTNET_NOLOGO=true
+ENV DOTNET_SDK_VERSION=6.0.413
+ENV DOTNET_USE_POLLING_FILE_WATCHER=true
+ENV NUGET_XMLDOC_MODE=skip
+# hadolint ignore=DL3008
+RUN export fromVersion=${FROM_VERSION} \
+    && deps=("libc6" "libgcc1" "libgssapi-krb5-2" "libstdc++6" "zlib1g") \
+    && if [ "${fromVersion}" = "20.04" ]; then deps+=("libicu66" "libssl1.1"); fi \
+    && if [ "${fromVersion}" = "22.04" ]; then deps+=("libicu70" "libssl3" "libunwind8"); fi \
+    && apt-get update && apt-get install -y --no-install-recommends --no-upgrade "${deps[@]}" \
+    && curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh \
     && chmod +x ./dotnet-install.sh \
-    && bash ./dotnet-install.sh --install-dir ${DOTNET_ROOT} --no-path --channel LTS \
-    && bash ./dotnet-install.sh --install-dir ${DOTNET_ROOT} --no-path --channel STS \
+    && ./dotnet-install.sh \
+        --install-dir "${DOTNET_ROOT}" \
+        --no-path \
+        --channel LTS \
+        --version "${DOTNET_SDK_VERSION}" \
     && rm -rf ./dotnet-install.sh \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && dotnet --info
 
-# Install Powershell
-ARG POWERSHELL_VERSION=7.3.6
-RUN curl -L -o packages-microsoft-prod.deb "https://packages.microsoft.com/config/ubuntu/${FROM_VERSION}/packages-microsoft-prod.deb" \
-    && dpkg -i packages-microsoft-prod.deb \
-    && rm packages-microsoft-prod.deb \
-    && apt-get update \
-    && if ! apt-get install -y --no-install-recommends powershell=${POWERSHELL_VERSION}*; then dotnet tool install --tool-path ${DOTNET_TOOLS} --no-cache --version ${POWERSHELL_VERSION} powershell; fi \
-    && rm -rf /var/lib/apt/lists/*
+# Install PowerShell global tool
+RUN export powershell_version=7.2.13 \
+    && curl -fSL \
+        --output PowerShell.Linux."$(cat /tmp/targetproc)".$powershell_version.nupkg \
+        https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux."$(cat /tmp/targetproc)".$powershell_version.nupkg \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install \
+        --add-source / \
+        --tool-path /usr/share/powershell \
+        --version $powershell_version \
+        PowerShell.Linux."$(cat /tmp/targetproc)" \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux."$(cat /tmp/targetproc)".$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm
 
-# # Install Azure Powershell Module v10.2.0
-# RUN pwsh -Command Set-PSRepository -Name PSGallery -InstallationPolicy Trusted \
-#     && pwsh -Command Install-Module -Name Az -RequiredVersion 10.2.0 -Scope AllUsers
+# # Install Azure Powershell Modules
+RUN export azVersion=10.2.0 \
+    && pwsh \
+        -NonInteractive \
+        -NoProfile \
+        -Command "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted" \
+    && pwsh \
+        -NonInteractive \
+        -NoProfile \
+        -Command "Install-Module -Name Az -RequiredVersion ${azVersion} -Scope AllUsers -Repository PSGallery"
 
 # Install Github CLI
 # hadolint ignore=DL3008
@@ -52,11 +81,17 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
 # Install Azure CLI
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash \
     && az extension add -n azure-devops \
-    && az bicep install --target-platform "linux-$(if [[ ${TARGETARCH} == "amd64" ]]; then echo x64; else echo ${TARGETARCH}; fi)" \
+    && az bicep install --target-platform "linux-$(cat /tmp/targetproc)" \
     && az config set bicep.use_binary_from_path=true \
+    && az config set auto-upgrade.enable=no \
+    && az config set auto-upgrade.prompt=no \
+    && az config set core.collect_telemetry=false \
     && rm -rf /var/lib/apt/lists/*
 
 # install bicep-cli
-RUN curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-"$(if [[ ${TARGETARCH} == "amd64" ]]; then echo x64; else echo ${TARGETARCH}; fi)" \
+RUN curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-"$(cat /tmp/targetproc)" \
     && chmod +x ./bicep \
     && mv ./bicep /usr/local/bin/bicep
+
+# clean tmp
+RUN rm -Rf /tmp/*


### PR DESCRIPTION
This update fixes issues with powershell. Now it is useable again unecessary if emulated via qemu or using host-arch :godmode: 

update Dockerfile:
- create /tmp/targetproc to get modified arch (x64) in installs
- set more DOTNET_ variables (inspired by `dotnet/dotnet-docker`)
- only install LTS version of .NET SDK
- install PowerShell as global Tool via .NET
- install Azure Powershell Modules
- disable Azure-CLI auto upgrade and telemetry
- clean /tmp as last build step

update ci.yml:
- set version tag only for main branch
- remove unused build-arg

update readme:
- add info how to use image with `nektos/act`