### PR TITLE
Don't push PRs, but always create SBOM

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -112,5 +112,8 @@
     "xvfb",
     "zstd",
     "zsync"
+  ],
+  "enableFiletypes": [
+    "github-actions-workflow"
   ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -113,7 +113,5 @@
     "zstd",
     "zsync"
   ],
-  "enableFiletypes": [
-    "github-actions-workflow"
-  ]
+  "enableFiletypes": ["github-actions-workflow"]
 }

--- a/.github/actions/free-space/action.yml
+++ b/.github/actions/free-space/action.yml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+
+name: Free some disk space
+author: mauwii
+description: |
+  This Action can be used to free up some disk-space on
+  github hosted runners
+
+inputs:
+  deleteDotnet:
+    description: free ~20 GB bei removing pre-cached .NET
+    required: false
+    default: 'false'
+  deleteAndroid:
+    description: free ~10 GB bei removing pre-cached Android SDK
+    required: false
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    # will release about 20GB if you don't need .NET
+    - name: Remove .NET
+      id: dotnet
+      if: fromJson(inputs.deleteDotnet)
+      shell: bash
+      run: |
+        for dir in /usr/share/dotnet /opt/hostedtoolcache/dotnet; do
+          if [ -d $dir ]; then
+            sudo rm -Rf $dir # Ubuntu 18/20
+          fi
+        done
+
+    # will release about 10 GB if you don't need Android
+    - name: Remove android sdk
+      id: android
+      if: fromJson(inputs.deleteAndroid)
+      shell: bash
+      run: |
+        if [ -d /usr/local/lib/android ]; then
+          sudo rm -rf /usr/local/lib/android
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,16 @@ permissions:
   packages: write
   actions: write
 
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: ${{ format('{0}/{1}', github.repository_owner, 'ubuntu-act') }}
+  SHA: ${{ github.event.pull_request.head.sha || github.event.after }}
+  DOCKERHUB_USERNAME: ${{ github.repository_owner }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.triggering_actor != 'github-actions[bot]'
     strategy:
       matrix:
         include:
@@ -36,11 +42,6 @@ jobs:
             distro: 'ubuntu'
             codename: 'focal'
             from-flavor: 'act'
-    env:
-      REGISTRY: docker.io
-      IMAGE_NAME: ubuntu-act
-      IMAGE_REPOSITORY: ${{ format('{0}/{1}', github.repository_owner, 'ubuntu-act') }}
-      SHA: ${{ github.event.pull_request.head.sha || github.event.after }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3.6.0
@@ -51,7 +52,11 @@ jobs:
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v2.10.0
+        with:
+          # Using the docker driver enables loading of the built image into the Docker daemon
+          driver: docker
+          driver-opts: image=moby/buildkit:v0.12.2,network=host
 
       # - name: Login to GitHub Container Registry
       #   uses: docker/login-action@v2.1.0
@@ -60,14 +65,15 @@ jobs:
       #     username: ${{ github.repository_owner }}
       #     password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Login against a Docker registry except on PR
+      # Login against a Docker registry
       # https://github.com/docker/login-action
       - name: Login to Docker Hub
         uses: docker/login-action@v2.2.0
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+          logout: true
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
@@ -76,21 +82,25 @@ jobs:
         uses: docker/metadata-action@v4.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          images: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}
+          images: ${{ env.IMAGE_NAME }} # ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}
           tags: |
             type=raw,value=${{ matrix.from-version }},enable={{is_default_branch}},priority=900
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.from-version == '22.04' }},priority=700
             type=ref,event=branch,prefix=${{ matrix.from-version }}-,priority=600
             type=sha,prefix=${{ matrix.from-version }}-,format=short,priority=100
           labels: |
+            org.opencontainers.image.authors=['${{ env.REPOSITORY_LINK }}','${{ github.actor }}']
             org.opencontainers.image.created={{date 'dddd, MMMM Do YYYY, h:mm:ss a'}}
+            org.opencontainers.image.description=${{ env.DESCRIPTION }}
+            org.opencontainers.image.documentation=${{ env.REPOSITORY_LINK }}
+            org.opencontainers.image.source=${{ env.SOURCE }}
+            org.opencontainers.image.title=${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}
+            org.opencontainers.image.url=${{ env.REPOSITORY_LINK }}/blob/${{ env.SHA }}/linux/${{ matrix.distro }}/Dockerfile
             org.opencontainers.image.vendor=${{ github.repository_owner }}
-            org.opencontainers.image.authors='["${{ github.repositoryUrl}}","${{ github.actor }}"]'
-            org.opencontainers.image.url=https://github.com/${{ github.repository }}/blob/${{ env.SHA }}/linux/${{ matrix.distro }}/Dockerfile
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
-            org.opencontainers.image.documentation=${{ github.repositoryUrl }}
-            org.opencontainers.image.title=${{ env.IMAGE_REPOSITORY }}:${{ github.head_ref || github.ref_name }}
-            org.opencontainers.image.description=${{ github.event.repository.description }}
+        env:
+          REPOSITORY_LINK: https://github.com/${{ github.repository }}
+          DESCRIPTION: ${{ github.event.repository.description }}
+          SOURCE: ${{ github.repositoryUrl }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -99,7 +109,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: ./linux/ubuntu/Dockerfile
+          file: ./linux/${{ matrix.distro }}/Dockerfile
           platforms: linux/amd64,linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -110,29 +120,37 @@ jobs:
             FROM_FLAVOR=${{ matrix.from-flavor }}
             DISTRO=${{ matrix.distro }}
             CODENAME=${{ matrix.codename }}
+          # caching to speed up the build
           cache-from: |
-            type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}:${{ github.head_ref || github.ref_name }}
-            type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}:cache-${{ matrix.codename }}
+            type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}:${{ github.head_ref || github.ref_name }}
+            type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}:cache-${{ matrix.codename }}
           cache-to: |
-            type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}:cache-${{ matrix.codename }},mode=max
+            type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}:cache-${{ matrix.codename }},mode=max
+          # this will give us some usefull information about the build
           provenance: mode=max
-          push: true
-          # push: ${{ github.event_name == 'push' && ! contains(fromJson('["dependabot[bot]","nektos/act"]'),github.actor) }}
-          # outputs: type=image,oci-mediatypes=true,push=true
+          # for PRs the sbom will get built in Docker Scout
+          sbom: ${{ github.event_name != 'pull_request' }}
+          # dependend on the event type, we either push or load the image
+          push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
+          # github-token for the repository context
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # vulnerability scanning to verify PRs
       - name: Docker Scout
         id: docker-scout
-        if: ${{ github.event_name == 'pull_request' }}
+        if: steps.build.outcome == 'success'
         continue-on-error: true
         uses: docker/scout-action@v0.23.4
         with:
-          command: quickview,compare
-          image: ${{ steps.meta.outputs.tags }}
-          to: ${{ format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_REPOSITORY, format('{0}-{1}', matrix.from-version, 'main')) }}
+          command: quickview,compare,sbom
+          to: ${{ format('{0}/{1}:{2}-{3}', env.REGISTRY, env.IMAGE_NAME, matrix.from-version, github.event.repository.default_branch) }}
+          organization: ${{ env.DOCKERHUB_USERNAME }}
           ignore-unchanged: true
           only-severities: critical,high
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           write-comment: true
+          keep-previous-comments: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # ToDo: Move into a separate workflow and depend on ci and mega-linter
   approve-pr:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,10 @@ jobs:
           images: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}
           tags: |
             type=raw,value=${{ matrix.from-version }},enable={{is_default_branch}},priority=900
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.from-version == '22.04' }},priority=700
-            type=ref,event=branch,prefix=${{ matrix.from-version }}-,priority=600
+            type=raw,value=${{ matrix.from-version }}-${{ github.head_ref || github.ref_name }},priority=600
             type=sha,prefix=${{ matrix.from-version }}-,format=short,priority=100
+          flavor:
+            latest=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.from-version == '22.04' }}
           labels: |
             org.opencontainers.image.authors=['${{ env.REPOSITORY_LINK }}','${{ github.actor }}']
             org.opencontainers.image.created={{date 'dddd, MMMM Do YYYY, h:mm:ss a'}}
@@ -133,7 +134,7 @@ jobs:
           sbom: ${{ github.event_name != 'pull_request' }}
           # depended on the event type, we either push or load the image
           push: ${{ github.event_name != 'pull_request' }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }}:${{ env.SHA }},push=false
+          # outputs: type=image,name=${{ env.REGISTRY_IMAGE }}:${{ matrix.from-version }}-${{ github.head_ref || github.ref_name }},push=true
         env:
           REGISTRY_IMAGE: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         uses: docker/metadata-action@v4.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          images: ${{ env.IMAGE_NAME }} # ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}
+          images: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}
           tags: |
             type=raw,value=${{ matrix.from-version }},enable={{is_default_branch}},priority=900
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.from-version == '22.04' }},priority=700

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
           ignore-unchanged: true
           only-severities: critical,high
           write-comment: true
-          keep-previous-comments: true
+          keep-previous-comments: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # ToDo: Move into a separate workflow and depend on ci and mega-linter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,11 +132,11 @@ jobs:
           # this will give us some usefull information about the build
           provenance: mode=max
           # for PRs the SBOM will be built in Docker Scout
-          sbom: true
+          sbom: ${{ github.event_name != 'pull_request' }}
           # sbom: ${{ github.event_name != 'pull_request' }}
           # dependend on the event type, we either push or load the image
           push: ${{ github.event_name != 'pull_request' }}
-          outputs: type=image,name=${{ steps.meta.outputs.tags }}
+          outputs: type=tar,dest=/tmp/${{ env.SHA }}.tar
         env:
           REGISTRY_IMAGE: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}
 
@@ -147,7 +147,8 @@ jobs:
         continue-on-error: true
         uses: docker/scout-action@v0.23.4
         with:
-          image: ${{ steps.meta.outputs.tags }}
+          image: /tmp/${{ env.SHA }}.tar
+          type: archive
           command: compare,sbom
           to: ${{ format('{0}/{1}:{2}-{3}', env.REGISTRY, env.IMAGE_NAME, matrix.from-version, github.event.repository.default_branch) }}
           ignore-unchanged: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,6 @@ on:
       - '**/toolsets/*.json'
       - '**/.github/workflows/ci.yml'
 
-permissions:
-  contents: read
-  pull-requests: write
-  packages: write
-  actions: write
-
 env:
   REGISTRY: docker.io
   IMAGE_NAME: ${{ format('{0}/{1}', github.repository_owner, 'ubuntu-act') }}
@@ -42,6 +36,10 @@ jobs:
             distro: 'ubuntu'
             codename: 'focal'
             from-flavor: 'act'
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3.6.0
@@ -147,12 +145,12 @@ jobs:
         continue-on-error: true
         uses: docker/scout-action@v0.23.4
         with:
-          command: compare,sbom
-          to: ${{ format('{0}/{1}:{2}-{3}', env.REGISTRY, env.IMAGE_NAME, matrix.from-version, github.event.repository.default_branch) }}
+          command: compare,recommendations
+          to: ${{ format('{0}/{1}:{2}-{3}', env.REGISTRY, env.IMAGE_NAME, matrix.from-version, 'main') }}
           organization: ${{ github.repository_owner }}
           ignore-unchanged: true
           only-severities: critical,high
-          write-comment: true
+          write-comment: ${{ github.actor != 'nektos/act' }}
           keep-previous-comments: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -162,6 +160,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     if: contains(fromJson('["mauwii","dependabot[bot]"]'), github.triggering_actor) && github.event_name == 'pull_request' &&  needs.build.result == 'success'
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: write
     steps:
       - name: Approve PR
         run: gh pr review --approve "$PR_URL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,11 +146,11 @@ jobs:
         uses: docker/scout-action@v0.23.4
         with:
           command: compare,recommendations
-          to: ${{ format('{0}/{1}:{2}-{3}', env.REGISTRY, env.IMAGE_NAME, matrix.from-version, 'main') }}
+          to: ${{ format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, matrix.from-version) }}
           organization: ${{ github.repository_owner }}
           ignore-unchanged: true
           only-severities: critical,high
-          write-comment: ${{ github.actor != 'nektos/act' }}
+          write-comment: false # ${{ github.actor != 'nektos/act' }}
           keep-previous-comments: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,7 @@ jobs:
           file: ./linux/${{ matrix.distro }}/Dockerfile
           platforms: linux/amd64,linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
-          tags: |
-            ${{ steps.meta.outputs.tags }}
-            ${{ env.IMAGE_REPOSITORY }}:${{ github.head_ref || github.ref_name }}
-            ${{ format('{0}:{1}', env.IMAGE_NAME, github.head_ref || github.ref_name)}}
+          tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             FROM_IMAGE=buildpack-deps
             FROM_VERSION_MAJOR=${{ matrix.from-version-major }}
@@ -150,7 +147,6 @@ jobs:
         uses: docker/scout-action@v0.23.4
         with:
           command: compare,recommendations
-          image: ${{ format('{0}:{1}', env.IMAGE_NAME, github.head_ref || github.ref_name) }}
           to: ${{ format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_REPOSITORY, matrix.from-version) }}
           organization: ${{ github.repository_owner }}
           ignore-unchanged: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,6 @@ on:
       - '**/toolsets/*.json'
       - '**/.github/workflows/ci.yml'
 
-env:
-  REGISTRY: docker.io
-  IMAGE_NAME: ${{ format('{0}/{1}', github.repository_owner, 'ubuntu-act') }}
-  SHA: ${{ github.event.pull_request.head.sha || github.event.after }}
-  DOCKERHUB_USERNAME: ${{ github.repository_owner }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -40,6 +33,13 @@ jobs:
       contents: read
       packages: write
       pull-requests: write
+    env:
+      REGISTRY: docker.io
+      IMAGE_NAME: ${{ format('{0}-{1}', matrix.distro, matrix.from-flavor) }}
+      IMAGE_REPOSITORY: ${{ format('{0}/{1}', github.repository_owner, format('{0}-{1}', matrix.distro, matrix.from-flavor)) }}
+      SHA: ${{ github.event.pull_request.head.sha || github.event.after }}
+      DOCKERHUB_USERNAME: ${{ github.repository_owner }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3.6.0
@@ -80,7 +80,7 @@ jobs:
         uses: docker/metadata-action@v4.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          images: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}
+          images: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}
           tags: |
             type=raw,value=${{ matrix.from-version }},enable={{is_default_branch}},priority=900
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.from-version == '22.04' }},priority=700
@@ -92,7 +92,7 @@ jobs:
             org.opencontainers.image.description=${{ env.DESCRIPTION }}
             org.opencontainers.image.documentation=${{ env.REPOSITORY_LINK }}
             org.opencontainers.image.source=${{ env.SOURCE }}
-            org.opencontainers.image.title=${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}
+            org.opencontainers.image.title=${{ env.IMAGE_REPOSITORY }}:${{ github.head_ref || github.ref_name }}
             org.opencontainers.image.url=${{ env.REPOSITORY_LINK }}/blob/${{ env.SHA }}/linux/${{ matrix.distro }}/Dockerfile
             org.opencontainers.image.vendor=${{ github.repository_owner }}
         env:
@@ -134,9 +134,9 @@ jobs:
           # sbom: ${{ github.event_name != 'pull_request' }}
           # dependend on the event type, we either push or load the image
           push: ${{ github.event_name != 'pull_request' }}
-          outputs: type=image,name=${{ env.IMAGE_NAME }}:${{ env.SHA }},push=false
+          outputs: type=image,name=${{ env.IMAGE_REPOSITORY }}:${{ env.SHA }},push=false
         env:
-          REGISTRY_IMAGE: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}
+          REGISTRY_IMAGE: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}
 
       # vulnerability scanning to verify PRs
       - name: Docker Scout
@@ -146,7 +146,8 @@ jobs:
         uses: docker/scout-action@v0.23.4
         with:
           command: compare,recommendations
-          to: ${{ format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, matrix.from-version) }}
+          image: ${{ format('{0}:{1}', env.IMAGE_NAME, env.SHA) }}
+          to: ${{ format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_REPOSITORY, matrix.from-version) }}
           organization: ${{ github.repository_owner }}
           ignore-unchanged: true
           only-severities: critical,high

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,7 @@ jobs:
       DOCKERHUB_USERNAME: ${{ github.repository_owner }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3.6.0
-        with:
-          ref: ${{ env.SHA }}
+      - uses: actions/checkout@v3.6.0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -85,12 +82,12 @@ jobs:
           tags: |
             type=raw,value=${{ matrix.from-version }},enable={{is_default_branch}},priority=900
             type=raw,value=${{ matrix.from-version }}-${{ github.head_ref || github.ref_name }},priority=600
-            type=sha,prefix=${{ matrix.from-version }}-,format=short,priority=100
-          flavor:
+            type=sha,prefix=${{ matrix.from-version }}-,format=short,enable={{is_default_branch}},priority=100
+          flavor: |
             latest=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.from-version == '22.04' }}
+
           labels: |
             org.opencontainers.image.authors=['${{ env.REPOSITORY_LINK }}','${{ github.actor }}']
-            org.opencontainers.image.created={{date 'dddd, MMMM Do YYYY, h:mm:ss a'}}
             org.opencontainers.image.description=${{ github.event.repository.description }}
             org.opencontainers.image.documentation=${{ env.REPOSITORY_LINK }}
             org.opencontainers.image.revision=${{ env.SHA }}
@@ -131,9 +128,9 @@ jobs:
           # this will give us some useful information about the build
           provenance: mode=max
           # for PRs the SBOM will be built in Docker Scout
-          sbom: ${{ github.event_name != 'pull_request' }}
+          sbom: true
           # depended on the event type, we either push or load the image
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           # outputs: type=image,name=${{ env.REGISTRY_IMAGE }}:${{ matrix.from-version }}-${{ github.head_ref || github.ref_name }},push=true
         env:
           REGISTRY_IMAGE: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.10.0
         with:
-          # Using the docker driver enables loading of the built image into the Docker daemon
-          # but unfortunately it doesn't support cache-export yet
-          driver: ${{ github.event_name == 'pull_request' && 'docker' || 'docker-container' }}
-          driver-opts: image=moby/buildkit:v0.12.2,network=host
+          driver-opts: |
+            image=moby/buildkit:v0.12.2
+            network=host
 
       # - name: Login to GitHub Container Registry
       #   uses: docker/login-action@v2.1.0
@@ -126,18 +125,17 @@ jobs:
             type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}:${{ github.head_ref || github.ref_name }}
             type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}:cache-${{ matrix.codename }}
           # cache exporter doesn't work with docker driver
-          cache-to: ${{ github.event_name != 'pull_request' && env.CACHE_TO || '' }}
+          cache-to: |
+            type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}:cache-${{ matrix.codename }},mode=max
           # this will give us some usefull information about the build
           provenance: mode=max
           # for PRs the sbom will get built in Docker Scout
           sbom: ${{ github.event_name != 'pull_request' }}
           # dependend on the event type, we either push or load the image
           push: ${{ github.event_name != 'pull_request' }}
-          load: ${{ github.event_name == 'pull_request' }}
+          # load: ${{ github.event_name == 'pull_request' }}
           # github-token for the repository context
           github-token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          CACHE_TO: type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}:cache-${{ matrix.codename }},mode=max
 
       # vulnerability scanning to verify PRs
       - name: Docker Scout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ jobs:
       DOCKERHUB_USERNAME: ${{ github.repository_owner }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
+      - uses: ./.github/actions/free-space
+        with:
+          deleteDotnet: 'true'
+          deleteAndroid: 'true'
+
       - uses: actions/checkout@v3.6.0
 
       - name: Set up QEMU

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,6 @@ jobs:
           image: ${{ steps.meta.outputs.tags }}
           command: compare,sbom
           to: ${{ format('{0}/{1}:{2}-{3}', env.REGISTRY, env.IMAGE_NAME, matrix.from-version, github.event.repository.default_branch) }}
-          organization: ${{ env.DOCKERHUB_USERNAME }}
           ignore-unchanged: true
           only-severities: critical,high
           write-comment: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,7 @@ jobs:
         uses: docker/metadata-action@v4.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          images: |
-            ${{ env.IMAGE_NAME }}
-            ${{ env.IMAGE_REPOSITORY }}
-            ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}
+          images: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}
           tags: |
             type=raw,value=${{ matrix.from-version }},enable={{is_default_branch}},priority=900
             type=raw,value=${{ matrix.from-version }}-${{ github.head_ref || github.ref_name }},priority=600

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.tags }}
             ${{ env.IMAGE_REPOSITORY }}:${{ github.head_ref || github.ref_name }}
-            ${{ format('{0}:{1}', env.IMAGE_NAME, github.head_ref || github.ref_name, )}}
+            ${{ format('{0}:{1}', env.IMAGE_NAME, github.head_ref || github.ref_name)}}
           build-args: |
             FROM_IMAGE=buildpack-deps
             FROM_VERSION_MAJOR=${{ matrix.from-version-major }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,8 @@ jobs:
         uses: docker/setup-buildx-action@v2.10.0
         with:
           # Using the docker driver enables loading of the built image into the Docker daemon
-          driver: docker
+          # but unfortunately it doesn't support cache-export yet
+          driver: ${{ github.event_name == 'pull_request' && 'docker' || 'docker-container' }}
           driver-opts: image=moby/buildkit:v0.12.2,network=host
 
       # - name: Login to GitHub Container Registry
@@ -124,8 +125,8 @@ jobs:
           cache-from: |
             type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}:${{ github.head_ref || github.ref_name }}
             type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}:cache-${{ matrix.codename }}
-          cache-to: |
-            type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}:cache-${{ matrix.codename }},mode=max
+          # cache exporter doesn't work with docker driver
+          cache-to: ${{ github.event_name != 'pull_request' && env.CACHE_TO || '' }}
           # this will give us some usefull information about the build
           provenance: mode=max
           # for PRs the sbom will get built in Docker Scout
@@ -135,6 +136,8 @@ jobs:
           load: ${{ github.event_name == 'pull_request' }}
           # github-token for the repository context
           github-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          CACHE_TO: type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}:cache-${{ matrix.codename }},mode=max
 
       # vulnerability scanning to verify PRs
       - name: Docker Scout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,6 @@ jobs:
         uses: docker/scout-action@v0.23.4
         with:
           image: ${{ steps.meta.outputs.tags }}
-          type: oci-dir
           command: quickview,compare,sbom
           to: ${{ format('{0}/{1}:{2}-{3}', env.REGISTRY, env.IMAGE_NAME, matrix.from-version, github.event.repository.default_branch) }}
           organization: ${{ env.DOCKERHUB_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,12 @@ jobs:
       DOCKERHUB_USERNAME: ${{ github.repository_owner }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
+      - uses: actions/checkout@v3.6.0
+
       - uses: ./.github/actions/free-space
         with:
           deleteDotnet: 'true'
           deleteAndroid: 'true'
-
-      - uses: actions/checkout@v3.6.0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
           organization: ${{ github.repository_owner }}
           ignore-unchanged: true
           only-severities: critical,high
-          write-comment: false # ${{ github.actor != 'nektos/act' }}
+          write-comment: ${{ github.actor != 'nektos/act' }}
           keep-previous-comments: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.10.0
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.12.2
-            network=host
+        # with:
+        #   driver-opts: |
+        #     image=moby/buildkit:v0.12.2
+        #     network=host
 
       # - name: Login to GitHub Container Registry
       #   uses: docker/login-action@v2.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         uses: docker/scout-action@v0.23.4
         with:
           image: ${{ steps.meta.outputs.tags }}
-          command: quickview,compare,sbom
+          command: compare,sbom
           to: ${{ format('{0}/{1}:{2}-{3}', env.REGISTRY, env.IMAGE_NAME, matrix.from-version, github.event.repository.default_branch) }}
           organization: ${{ env.DOCKERHUB_USERNAME }}
           ignore-unchanged: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3.6.0
 
-      - uses: ./.github/actions/free-space
+      - name: Free up disk space
+        uses: ./.github/actions/free-space
         with:
           deleteDotnet: 'true'
           deleteAndroid: 'true'
@@ -83,14 +84,16 @@ jobs:
         uses: docker/metadata-action@v4.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          images: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}
+          images: |
+            ${{ env.IMAGE_NAME }}
+            ${{ env.IMAGE_REPOSITORY }}
+            ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}
           tags: |
             type=raw,value=${{ matrix.from-version }},enable={{is_default_branch}},priority=900
             type=raw,value=${{ matrix.from-version }}-${{ github.head_ref || github.ref_name }},priority=600
             type=sha,prefix=${{ matrix.from-version }}-,format=short,enable={{is_default_branch}},priority=100
           flavor: |
             latest=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.from-version == '22.04' }}
-
           labels: |
             org.opencontainers.image.authors=['${{ env.REPOSITORY_LINK }}','${{ github.actor }}']
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -133,7 +136,7 @@ jobs:
           # this will give us some useful information about the build
           provenance: mode=max
           # for PRs the SBOM will be built in Docker Scout
-          sbom: true
+          # sbom: true
           # depended on the event type, we either push or load the image
           push: true
           # outputs: type=image,name=${{ env.REGISTRY_IMAGE }}:${{ matrix.from-version }}-${{ github.head_ref || github.ref_name }},push=true
@@ -143,11 +146,10 @@ jobs:
       # vulnerability scanning to verify PRs
       - name: Docker Scout
         id: docker-scout
-        if: success() && github.event_name == 'pull_request'
         continue-on-error: true
         uses: docker/scout-action@v0.23.4
         with:
-          command: recommendations,compare
+          command: recommendations,sbom,compare
           image: ${{ steps.meta.outputs.tags }}
           to: ${{ format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_REPOSITORY, matrix.from-version) }}
           organization: ${{ github.repository_owner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,16 +90,15 @@ jobs:
           labels: |
             org.opencontainers.image.authors=['${{ env.REPOSITORY_LINK }}','${{ github.actor }}']
             org.opencontainers.image.created={{date 'dddd, MMMM Do YYYY, h:mm:ss a'}}
-            org.opencontainers.image.description=${{ env.DESCRIPTION }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
             org.opencontainers.image.documentation=${{ env.REPOSITORY_LINK }}
-            org.opencontainers.image.source=${{ env.SOURCE }}
+            org.opencontainers.image.revision=${{ env.SHA }}
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
             org.opencontainers.image.title=${{ env.IMAGE_REPOSITORY }}:${{ github.head_ref || github.ref_name }}
             org.opencontainers.image.url=${{ env.REPOSITORY_LINK }}/blob/${{ env.SHA }}/linux/${{ matrix.distro }}/Dockerfile
             org.opencontainers.image.vendor=${{ github.repository_owner }}
         env:
           REPOSITORY_LINK: https://github.com/${{ github.repository }}
-          DESCRIPTION: ${{ github.event.repository.description }}
-          SOURCE: ${{ github.repositoryUrl }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -146,6 +145,7 @@ jobs:
         uses: docker/scout-action@v0.23.4
         with:
           command: recommendations,compare
+          image: ${{ steps.meta.outputs.tags }}
           to: ${{ format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_REPOSITORY, matrix.from-version) }}
           organization: ${{ github.repository_owner }}
           ignore-unchanged: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,8 @@ jobs:
           # this will give us some usefull information about the build
           provenance: mode=max
           # for PRs the SBOM will be built in Docker Scout
-          sbom: ${{ github.event_name != 'pull_request' }}
+          sbom: true
+          # sbom: ${{ github.event_name != 'pull_request' }}
           # dependend on the event type, we either push or load the image
           push: ${{ github.event_name != 'pull_request' }}
           outputs: type=image,name=${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
           sbom: ${{ github.event_name != 'pull_request' }}
           # depended on the event type, we either push or load the image
           push: ${{ github.event_name != 'pull_request' }}
-          outputs: type=image,name=${{ env.IMAGE_REPOSITORY }}:${{ env.SHA }},push=false
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }}:${{ env.SHA }},push=false
         env:
           REGISTRY_IMAGE: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           # sbom: ${{ github.event_name != 'pull_request' }}
           # dependend on the event type, we either push or load the image
           push: ${{ github.event_name != 'pull_request' }}
-          outputs: type=tar,dest=/tmp/${{ env.SHA }}.tar
+          outputs: type=image,name=${{ env.IMAGE_NAME }}:${{ env.SHA }},push=false
         env:
           REGISTRY_IMAGE: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}
 
@@ -147,10 +147,9 @@ jobs:
         continue-on-error: true
         uses: docker/scout-action@v0.23.4
         with:
-          image: /tmp/${{ env.SHA }}.tar
-          type: archive
           command: compare,sbom
           to: ${{ format('{0}/{1}:{2}-{3}', env.REGISTRY, env.IMAGE_NAME, matrix.from-version, github.event.repository.default_branch) }}
+          organization: ${{ github.repository_owner }}
           ignore-unchanged: true
           only-severities: critical,high
           write-comment: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,10 @@ jobs:
           file: ./linux/${{ matrix.distro }}/Dockerfile
           platforms: linux/amd64,linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ env.IMAGE_REPOSITORY }}:${{ github.head_ref || github.ref_name }}
+            ${{ format('{0}:{1}', env.IMAGE_NAME, github.head_ref || github.ref_name, )}}
           build-args: |
             FROM_IMAGE=buildpack-deps
             FROM_VERSION_MAJOR=${{ matrix.from-version-major }}
@@ -138,6 +141,7 @@ jobs:
         env:
           REGISTRY_IMAGE: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}
 
+
       # vulnerability scanning to verify PRs
       - name: Docker Scout
         id: docker-scout
@@ -146,7 +150,7 @@ jobs:
         uses: docker/scout-action@v0.23.4
         with:
           command: compare,recommendations
-          image: ${{ format('{0}:{1}', env.IMAGE_NAME, env.SHA) }}
+          image: ${{ format('{0}:{1}', env.IMAGE_NAME, github.head_ref || github.ref_name, )}}
           to: ${{ format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_REPOSITORY, matrix.from-version) }}
           organization: ${{ github.repository_owner }}
           ignore-unchanged: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ on:
       - '**/toolsets/*.json'
       - '**/.github/workflows/ci.yml'
 
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -29,10 +34,6 @@ jobs:
             distro: 'ubuntu'
             codename: 'focal'
             from-flavor: 'act'
-    permissions:
-      contents: read
-      packages: write
-      pull-requests: write
     env:
       REGISTRY: docker.io
       IMAGE_NAME: ${{ format('{0}-{1}', matrix.distro, matrix.from-flavor) }}
@@ -127,12 +128,12 @@ jobs:
           # cache exporter doesn't work with docker driver
           cache-to: |
             type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-${{ matrix.codename }},mode=max
-          # this will give us some usefull information about the build
+          # this will give us some useful information about the build
           provenance: mode=max
           # for PRs the SBOM will be built in Docker Scout
           sbom: ${{ github.event_name != 'pull_request' }}
           # sbom: ${{ github.event_name != 'pull_request' }}
-          # dependend on the event type, we either push or load the image
+          # depended on the event type, we either push or load the image
           push: ${{ github.event_name != 'pull_request' }}
           outputs: type=image,name=${{ env.IMAGE_REPOSITORY }}:${{ env.SHA }},push=false
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
             CODENAME=${{ matrix.codename }}
           # caching to speed up the build
           cache-from: |
-            type=registry,ref=${{ env.REGISTRY_IMAGE }}:${{ github.head_ref || github.ref_name }}
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:${{ matrix.from-version }}-${{ github.head_ref || github.ref_name }}
             type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-${{ matrix.codename }}
           # cache exporter doesn't work with docker driver
           cache-to: |
@@ -132,7 +132,6 @@ jobs:
           provenance: mode=max
           # for PRs the SBOM will be built in Docker Scout
           sbom: ${{ github.event_name != 'pull_request' }}
-          # sbom: ${{ github.event_name != 'pull_request' }}
           # depended on the event type, we either push or load the image
           push: ${{ github.event_name != 'pull_request' }}
           outputs: type=image,name=${{ env.IMAGE_REPOSITORY }}:${{ env.SHA }},push=false
@@ -140,35 +139,20 @@ jobs:
           REGISTRY_IMAGE: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}
 
       # vulnerability scanning to verify PRs
-      - name: Docker Scout recommendations
-        id: docker-scout-recommendations
-        if: success()
+      - name: Docker Scout
+        id: docker-scout
+        if: success() && github.event_name == 'pull_request'
         continue-on-error: true
         uses: docker/scout-action@v0.23.4
         with:
-          command: recommendations
+          command: recommendations,compare
           to: ${{ format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_REPOSITORY, matrix.from-version) }}
           organization: ${{ github.repository_owner }}
           ignore-unchanged: true
-          only-severities: critical,high
-          write-comment: ${{ github.actor != 'nektos/act' && github.event_name == 'pull_request' }}
-          keep-previous-comments: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      # vulnerability scanning to verify PRs
-      - name: Docker Scout compare
-        id: docker-scout-compare
-        if: success()
-        continue-on-error: true
-        uses: docker/scout-action@v0.23.4
-        with:
-          command: compare
-          to: ${{ format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_REPOSITORY, matrix.from-version) }}
-          organization: ${{ github.repository_owner }}
-          ignore-unchanged: true
-          only-severities: critical,high
-          write-comment: ${{ github.actor != 'nektos/act' && github.event_name == 'pull_request' }}
-          keep-previous-comments: false
+          only-severities: high
+          write-comment: ${{ github.actor != 'nektos/act' }}
+          keep-previous-comments: true
+          summary: ${{ github.actor != 'nektos/act' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # ToDo: Move into a separate workflow and depend on ci and mega-linter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,18 +140,34 @@ jobs:
           REGISTRY_IMAGE: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}
 
       # vulnerability scanning to verify PRs
-      - name: Docker Scout
-        id: docker-scout
-        if: steps.build.outcome == 'success'
+      - name: Docker Scout recommendations
+        id: docker-scout-recommendations
+        if: success()
         continue-on-error: true
         uses: docker/scout-action@v0.23.4
         with:
-          command: compare,recommendations
+          command: recommendations
           to: ${{ format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_REPOSITORY, matrix.from-version) }}
           organization: ${{ github.repository_owner }}
           ignore-unchanged: true
           only-severities: critical,high
-          write-comment: ${{ github.actor != 'nektos/act' }}
+          write-comment: ${{ github.actor != 'nektos/act' && github.event_name == 'pull_request' }}
+          keep-previous-comments: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # vulnerability scanning to verify PRs
+      - name: Docker Scout compare
+        id: docker-scout-compare
+        if: success()
+        continue-on-error: true
+        uses: docker/scout-action@v0.23.4
+        with:
+          command: compare
+          to: ${{ format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_REPOSITORY, matrix.from-version) }}
+          organization: ${{ github.repository_owner }}
+          ignore-unchanged: true
+          only-severities: critical,high
+          write-comment: ${{ github.actor != 'nektos/act' && github.event_name == 'pull_request' }}
           keep-previous-comments: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          # github-token for the repository context
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           file: ./linux/${{ matrix.distro }}/Dockerfile
           platforms: linux/amd64,linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
@@ -122,20 +124,20 @@ jobs:
             CODENAME=${{ matrix.codename }}
           # caching to speed up the build
           cache-from: |
-            type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}:${{ github.head_ref || github.ref_name }}
-            type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}:cache-${{ matrix.codename }}
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:${{ github.head_ref || github.ref_name }}
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-${{ matrix.codename }}
           # cache exporter doesn't work with docker driver
           cache-to: |
-            type=registry,ref=${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}:cache-${{ matrix.codename }},mode=max
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-${{ matrix.codename }},mode=max
           # this will give us some usefull information about the build
           provenance: mode=max
-          # for PRs the sbom will get built in Docker Scout
+          # for PRs the SBOM will be built in Docker Scout
           sbom: ${{ github.event_name != 'pull_request' }}
           # dependend on the event type, we either push or load the image
           push: ${{ github.event_name != 'pull_request' }}
-          # load: ${{ github.event_name == 'pull_request' }}
-          # github-token for the repository context
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          outputs: type=oci,dest=/tmp/image.tar
+        env:
+          REGISTRY_IMAGE: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}
 
       # vulnerability scanning to verify PRs
       - name: Docker Scout
@@ -144,6 +146,8 @@ jobs:
         continue-on-error: true
         uses: docker/scout-action@v0.23.4
         with:
+          image: /tmp/image.tar
+          type: oci-dir
           command: quickview,compare,sbom
           to: ${{ format('{0}/{1}:{2}-{3}', env.REGISTRY, env.IMAGE_NAME, matrix.from-version, github.event.repository.default_branch) }}
           organization: ${{ env.DOCKERHUB_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,6 @@ jobs:
         env:
           REGISTRY_IMAGE: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_REPOSITORY) }}
 
-
       # vulnerability scanning to verify PRs
       - name: Docker Scout
         id: docker-scout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
           sbom: ${{ github.event_name != 'pull_request' }}
           # dependend on the event type, we either push or load the image
           push: ${{ github.event_name != 'pull_request' }}
-          outputs: type=oci,dest=/tmp/image.tar
+          outputs: type=image,name=${{ steps.meta.outputs.tags }}
         env:
           REGISTRY_IMAGE: ${{ format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}
 
@@ -146,7 +146,7 @@ jobs:
         continue-on-error: true
         uses: docker/scout-action@v0.23.4
         with:
-          image: /tmp/image.tar
+          image: ${{ steps.meta.outputs.tags }}
           type: oci-dir
           command: quickview,compare,sbom
           to: ${{ format('{0}/{1}:{2}-{3}', env.REGISTRY, env.IMAGE_NAME, matrix.from-version, github.event.repository.default_branch) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
         uses: docker/scout-action@v0.23.4
         with:
           command: compare,recommendations
-          image: ${{ format('{0}:{1}', env.IMAGE_NAME, github.head_ref || github.ref_name, )}}
+          image: ${{ format('{0}:{1}', env.IMAGE_NAME, github.head_ref || github.ref_name) }}
           to: ${{ format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_REPOSITORY, matrix.from-version) }}
           organization: ${{ github.repository_owner }}
           ignore-unchanged: true

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -9,11 +9,11 @@ on:
   pull_request:
     branches: [master, main]
 
-env: # Comment env block if you do not want to apply fixes
-  # Apply linter fixes configuration
-  APPLY_FIXES: all # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)
-  APPLY_FIXES_EVENT: pull_request # Decide which event triggers application of fixes in a commit or a PR (pull_request, push, all)
-  APPLY_FIXES_MODE: commit # If APPLY_FIXES is used, defines if the fixes are directly committed (commit) or posted in a PR (pull_request)
+# env: # Comment env block if you do not want to apply fixes
+#   # Apply linter fixes configuration
+#   APPLY_FIXES: all # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)
+#   APPLY_FIXES_EVENT: pull_request # Decide which event triggers application of fixes in a commit or a PR (pull_request, push, all)
+#   APPLY_FIXES_MODE: commit # If APPLY_FIXES is used, defines if the fixes are directly committed (commit) or posted in a PR (pull_request)
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -9,11 +9,11 @@ on:
   pull_request:
     branches: [master, main]
 
-# env: # Comment env block if you do not want to apply fixes
-#   # Apply linter fixes configuration
-#   APPLY_FIXES: all # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)
-#   APPLY_FIXES_EVENT: pull_request # Decide which event triggers application of fixes in a commit or a PR (pull_request, push, all)
-#   APPLY_FIXES_MODE: commit # If APPLY_FIXES is used, defines if the fixes are directly committed (commit) or posted in a PR (pull_request)
+env: # Comment env block if you do not want to apply fixes
+  # Apply linter fixes configuration
+  APPLY_FIXES: none # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)
+  APPLY_FIXES_EVENT: pull_request # Decide which event triggers application of fixes in a commit or a PR (pull_request, push, all)
+  APPLY_FIXES_MODE: commit # If APPLY_FIXES is used, defines if the fixes are directly committed (commit) or posted in a PR (pull_request)
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}


### PR DESCRIPTION
- don't push PRs
- move env to workflow level
- use env vars for docker credentials
- remove uneeded conditions
- update action versions
- use docker driver with most recent buildkit
  - played around a bit and this gave me best manifests
  - when used locally with act it even uses the builder from my local
  - it stores/reads built images in/from my local
- logout from dockerhub when job is done
- alphabetically sort labels
- add more comments